### PR TITLE
Lint Javadoc + Refactoring + Added class

### DIFF
--- a/plugin-core/src/main/java/org/ligoj/app/dao/SubscriptionRepository.java
+++ b/plugin-core/src/main/java/org/ligoj/app/dao/SubscriptionRepository.java
@@ -101,24 +101,6 @@ public interface SubscriptionRepository extends RestRepository<Subscription, Int
 	List<Object[]> findAllWithValuesByNode(String node);
 
 	/**
-	 * Return the subscriptions of given project with all non secured parameters.
-	 * 
-	 * @param node
-	 *            The node name
-	 * @param parameter
-	 *            The id of the parameter
-	 * @param project
-	 *            the subscribed project
-	 * @param criteria
-	 *            The search criteria to match with the data value
-	 * @return A list of table of [Subscription, ParameterValue]
-	 */
-	@Query("SELECT s, p FROM Subscription s, ParameterValue p LEFT JOIN p.subscription subscription INNER JOIN FETCH p.parameter param "
-			+ " LEFT JOIN p.node n0 LEFT JOIN n0.refined n1 LEFT JOIN n1.refined n2"
-			+ " WHERE s.project.id = ?3 AND (subscription = s OR n0.id = ?1 OR n1.refined = ?1 OR n2.refined = ?1) AND param.id LIKE ?2 AND UPPER(p.data) LIKE UPPER(CONCAT(CONCAT('%',?4),'%')) AND param.secured != TRUE")
-	List<Object[]> findAllWithValuesSecureByNodeByProject(String node, String parameter, int project, String criteria);
-
-	/**
 	 * Count subscriptions by project's identifier.
 	 * 
 	 * @param project

--- a/plugin-core/src/main/java/org/ligoj/app/resource/node/ParameterValueResource.java
+++ b/plugin-core/src/main/java/org/ligoj/app/resource/node/ParameterValueResource.java
@@ -5,6 +5,7 @@ package org.ligoj.app.resource.node;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -48,6 +49,7 @@ import org.ligoj.app.model.Parameter;
 import org.ligoj.app.model.ParameterType;
 import org.ligoj.app.model.ParameterValue;
 import org.ligoj.app.model.Subscription;
+import org.ligoj.app.resource.subscription.SubscriptionResource;
 import org.ligoj.bootstrap.core.crypto.CryptoHelper;
 import org.ligoj.bootstrap.core.resource.BusinessException;
 import org.ligoj.bootstrap.core.security.SecurityHelper;
@@ -92,6 +94,9 @@ public class ParameterValueResource {
 
 	@Autowired
 	private SubscriptionRepository subscriptionRepository;
+
+	@Autowired
+	private SubscriptionResource subscriptionResource;
 
 	@Autowired
 	private NodeResource nodeResource;
@@ -559,7 +564,7 @@ public class ParameterValueResource {
 		}
 
 		// Updated or created value
-		ParameterValue entity = existing.get(value.getParameter());
+		final ParameterValue entity = existing.get(value.getParameter());
 		if (entity == null) {
 			// Need to parse and recreate the value
 			return createInternal(value);
@@ -683,5 +688,29 @@ public class ParameterValueResource {
 			}
 			return vo;
 		}).collect(Collectors.toList());
+	}
+
+	/**
+	 * Returns the list of {@link ParameterValue} with given node and project.
+	 * 
+	 * @param node
+	 *            The node identifier subscribed.
+	 * @param project
+	 *            Project identifier
+	 * @param parameter
+	 *            The id of the parameter.
+	 * @param criteria
+	 *            the optional criteria used to check name (CN).
+	 * @return The list of object containing for each entry the {@link Subscription} and its associated
+	 *         {@link ParameterValue}
+	 */
+	@GET
+	@Path("{project}/{parameter}/{node}/{criteria}")
+	public Collection<ParameterValueVo> findAll(@PathParam("project") final int project,
+			@PathParam("parameter") final String parameter, @PathParam("node") final String node,
+			@PathParam("criteria") final String criteria) {
+		subscriptionResource.checkVisibleProject(project);
+		return repository.findAll(node, parameter, project, criteria).stream()
+				.map(this::toVo).collect(Collectors.toList());
 	}
 }

--- a/plugin-core/src/main/java/org/ligoj/app/resource/subscription/SubscriptionResource.java
+++ b/plugin-core/src/main/java/org/ligoj/app/resource/subscription/SubscriptionResource.java
@@ -41,7 +41,6 @@ import org.ligoj.app.dao.SubscriptionRepository;
 import org.ligoj.app.model.EventType;
 import org.ligoj.app.model.Node;
 import org.ligoj.app.model.Parameter;
-import org.ligoj.app.model.ParameterValue;
 import org.ligoj.app.model.Project;
 import org.ligoj.app.model.Subscription;
 import org.ligoj.app.resource.node.AbstractLockedResource;
@@ -381,7 +380,7 @@ public class SubscriptionResource extends AbstractLockedResource<Subscription, I
 	 *            Project's identifier.
 	 * @return the loaded project.
 	 */
-	private Project checkVisibleProject(final int id) {
+	public Project checkVisibleProject(final int id) {
 		final Project project = projectRepository.findOneVisible(id, securityHelper.getLogin());
 		if (project == null) {
 			// Associated project is not visible
@@ -574,27 +573,4 @@ public class SubscriptionResource extends AbstractLockedResource<Subscription, I
 		return (Class) LongTaskRunnerSubscription.class;
 	}
 
-	/**
-	 * Returns the list of {@link Subscription} and there {@link ParameterValue} with given node and project.
-	 * 
-	 * @param node
-	 *            Node identifier
-	 * @param project
-	 *            Project identifier
-	 * @param parameter
-	 *            The parameter id
-	 * @param criteria
-	 *            The user input corresponding to the value searched in the data attribute of the parameter value
-	 * @return The list of object containing for each entry the {@link Subscription} and its associated
-	 *         {@link ParameterValue}
-	 */
-	@GET
-	@Path("{project}/{parameter}/{node}/{criteria}")
-	public List<Object[]> getSubscriptionsWithParameterValues(@PathParam("project") final int project,
-			@PathParam("parameter") final String parameter, @PathParam("node") final String node,
-			@PathParam("criteria") final String criteria) {
-		checkVisibleProject(project);
-		checkManagedProject(project);
-		return repository.findAllWithValuesSecureByNodeByProject(node, parameter, project, criteria);
-	}
 }

--- a/plugin-core/src/test/java/org/ligoj/app/resource/node/ParameterValueResourceTest.java
+++ b/plugin-core/src/test/java/org/ligoj/app/resource/node/ParameterValueResourceTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.ligoj.app.AbstractAppTest;
 import org.ligoj.app.dao.ParameterRepository;
 import org.ligoj.app.dao.ParameterValueRepository;
+import org.ligoj.app.dao.ProjectRepository;
 import org.ligoj.app.model.Node;
 import org.ligoj.app.model.Parameter;
 import org.ligoj.app.model.ParameterValue;
@@ -58,6 +59,9 @@ public class ParameterValueResourceTest extends AbstractAppTest {
 
 	@Autowired
 	private ParameterValueResource resource;
+
+	@Autowired
+	private ProjectRepository projectRepository;
 
 	@Autowired
 	private StringEncryptor encryptor;
@@ -790,5 +794,17 @@ public class ParameterValueResourceTest extends AbstractAppTest {
 		final Node node = new Node();
 		node.setId("service:id:ldap:dig");
 		resource.update(values, node);
+	}
+
+	@Test
+	public void findAll() throws IOException {
+		final int projectId = projectRepository.findByName("MDA").getId();
+		final List<ParameterValueVo> parameterValues = new ArrayList<>(
+				resource.findAll(projectId, "service:bt:jira:pkey", "service:bt:jira:4", "MD"));
+		Assertions.assertEquals(1, parameterValues.size());
+
+		final ParameterValueVo pValue = parameterValues.get(0);
+		Assertions.assertEquals("MDA", pValue.getText());
+
 	}
 }

--- a/plugin-core/src/test/java/org/ligoj/app/resource/subscription/SubscriptionResourceTest.java
+++ b/plugin-core/src/test/java/org/ligoj/app/resource/subscription/SubscriptionResourceTest.java
@@ -43,9 +43,7 @@ import org.ligoj.app.iam.model.ReceiverType;
 import org.ligoj.app.model.CacheProjectGroup;
 import org.ligoj.app.model.DelegateNode;
 import org.ligoj.app.model.Event;
-import org.ligoj.app.model.Node;
 import org.ligoj.app.model.Parameter;
-import org.ligoj.app.model.ParameterValue;
 import org.ligoj.app.model.Project;
 import org.ligoj.app.model.Subscription;
 import org.ligoj.app.model.TaskSampleSubscription;
@@ -740,26 +738,6 @@ public class SubscriptionResourceTest extends AbstractOrgTest {
 	public void checkStatus() {
 		Assertions.assertTrue(
 				servicePluginLocator.getResource("service:bt:jira:4", JiraPluginResource.class).checkStatus(null));
-	}
-
-	@Test
-	public void getSubscriptionsWithParameterValues() throws IOException {
-		persistEntities("csv",
-				new Class[] { Node.class, Subscription.class, Event.class, Parameter.class, ParameterValue.class },
-				StandardCharsets.UTF_8.name());
-		final int projectId = projectRepository.findByName("MDA").getId();
-		List<Object[]> subscriptions = resource.getSubscriptionsWithParameterValues(projectId, "service:bt:jira:pkey",
-				"service:bt:jira:4", "MD");
-		Assertions.assertEquals(1, subscriptions.size());
-
-		final Object[] firstValue = subscriptions.get(0);
-		final Subscription subscription = (Subscription) firstValue[0];
-		final ParameterValue pValue = (ParameterValue) firstValue[1];
-		Assertions.assertEquals("MDA", subscription.getProject().getName());
-		Assertions.assertEquals("MDA", pValue.getData());
-		Assertions.assertEquals("service:bt:jira:pkey", pValue.getParameter().getId());
-		Assertions.assertEquals("service:bt:jira:4", pValue.getSubscription().getNode().getId());
-
 	}
 
 }


### PR DESCRIPTION
## Lint Javadoc
- Took example from other functions like asked
## Refactoring
- Moved findAllWithValuesSecureByNodeByProject from SubscriptionRepository to ParameterValueRepository
- Moved findAllWithValuesSecureByNodeByProject from SubscriptionResource to ParameterValueResource
- Setted checkVisibleProject to public in SubscriptionResource to be able to use it in ParameterValueResource
- Changed "LIKE" to "=" and "p" to "v"in findAllWithValuesSecureByNodeByProject in ParameterValueRepository
- Added a class org.ligoj.app.resource.node.ParameterValueListVo
- Added a function toParameterValues in ParameterValueResource
- Moved Junits to ParameterValueResourceTest and corrected them
