### PR TITLE
feat(api): add ServicePlugin.getPreferredColor() with parent chain inheritance

### DIFF
--- a/plugin-api/src/main/java/org/ligoj/app/api/ServicePlugin.java
+++ b/plugin-api/src/main/java/org/ligoj/app/api/ServicePlugin.java
@@ -56,4 +56,23 @@ public interface ServicePlugin extends org.ligoj.bootstrap.core.plugin.FeaturePl
 	default void delete(String node, boolean remoteData) throws Exception { // NOSONAR Everything could happen
 		// No custom data by default
 	}
+
+	/**
+	 * Return a hex color string (e.g. "#0052CC") representing this plugin's
+	 * brand or preferred color. The UI can use this value to accent the
+	 * card or any visual element associated with this service/tool.
+	 *
+	 * Default returns {@code null}, meaning no preference is declared:
+	 * the UI is then expected to fall back to its own derivation (icon
+	 * color extraction, deterministic palette, etc.).
+	 *
+	 * The returned value, when non-null, MUST be a CSS-compatible color
+	 * string. Hex format ({@code #rrggbb} or {@code #rgb}) is preferred
+	 * for portability.
+	 *
+	 * @return A CSS color string (hex preferred) or null when no preference.
+	 */
+	default String getPreferredColor() {
+		return null;
+	}
 }

--- a/plugin-api/src/test/java/org/ligoj/app/api/ServicePluginTest.java
+++ b/plugin-api/src/test/java/org/ligoj/app/api/ServicePluginTest.java
@@ -3,6 +3,7 @@
  */
 package org.ligoj.app.api;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -30,5 +31,10 @@ class ServicePluginTest {
 	@Test
 	void deleteNode() throws Exception {
 		plugin.delete("service:s1:t2:n3", true);
+	}
+
+	@Test
+	void getPreferredColor() {
+		Assertions.assertNull(plugin.getPreferredColor());
 	}
 }

--- a/plugin-core/src/main/java/org/ligoj/app/api/NodeVo.java
+++ b/plugin-core/src/main/java/org/ligoj/app/api/NodeVo.java
@@ -39,6 +39,14 @@ public class NodeVo extends AbstractNodeVo implements Refining<NodeVo> {
 	private String uiClasses;
 
 	/**
+	 * CSS color string declared by the plugin via
+	 * {@link ServicePlugin#getPreferredColor()}. {@code null} when no
+	 * preference is declared; the UI is expected to fall back to its
+	 * own derivation in that case.
+	 */
+	private String preferredColor;
+
+	/**
 	 * Parameter values attached to this node directly of from one of its parent. So some parameters come from the
 	 * parent node and are not directly linked to the current node.<br>
 	 * Depending on the called service to build this node, sometimes for the performance purpose, the values are not

--- a/plugin-core/src/main/java/org/ligoj/app/resource/node/NodeHelper.java
+++ b/plugin-core/src/main/java/org/ligoj/app/resource/node/NodeHelper.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.ligoj.app.api.NodeVo;
+import org.ligoj.app.api.ServicePlugin;
 import org.ligoj.app.model.Node;
 import org.ligoj.app.model.Parameter;
 import org.ligoj.app.model.ParameterType;
@@ -96,7 +97,48 @@ public class NodeHelper {
 	public static NodeVo toVo(final Node entity, final ServicePluginLocator locator) {
 		final var vo = toVo(entity);
 		vo.setEnabled(locator.isEnabled(entity.getId()));
+		applyPlugin(vo, entity, locator);
 		return vo;
+	}
+
+	/**
+	 * Apply plugin-derived metadata on the VO when a ServicePlugin is
+	 * registered for this node. Currently fills {@link NodeVo#getPreferredColor()}
+	 * from {@link ServicePlugin#getPreferredColor()}, walking up the parent
+	 * chain to inherit a color declared at the service level when the leaf
+	 * tool does not override it.
+	 *
+	 * @param vo      The target value object to enrich.
+	 * @param entity  The source node entity.
+	 * @param locator The plugin locator.
+	 */
+	private static void applyPlugin(final NodeVo vo, final Node entity, final ServicePluginLocator locator) {
+		vo.setPreferredColor(resolvePreferredColor(entity, locator));
+	}
+
+	/**
+	 * Walk up the parent chain to resolve the preferred color, returning the
+	 * first non-null value found. Returns {@code null} when no plugin in the
+	 * chain declares a color (default behavior).
+	 *
+	 * @param entity  The starting node.
+	 * @param locator The plugin locator.
+	 * @return The hex color string, or {@code null} when no color is declared
+	 *         anywhere on the chain.
+	 */
+	private static String resolvePreferredColor(final Node entity, final ServicePluginLocator locator) {
+		Node current = entity;
+		while (current != null) {
+			final var plugin = locator.getResource(current.getId(), ServicePlugin.class);
+			if (plugin != null) {
+				final String color = plugin.getPreferredColor();
+				if (color != null) {
+					return color;
+				}
+			}
+			current = current.getRefined();
+		}
+		return null;
 	}
 
 	/**
@@ -123,6 +165,7 @@ public class NodeHelper {
 	private static NodeVo toVoParameter(final Node entity, final ServicePluginLocator locator) {
 		final var vo = toVoParameter(entity);
 		vo.setEnabled(locator.isEnabled(entity.getId()));
+		applyPlugin(vo, entity, locator);
 		return vo;
 	}
 
@@ -150,6 +193,7 @@ public class NodeHelper {
 	protected static NodeVo toVoLight(final Node entity, final ServicePluginLocator locator) {
 		final var vo = toVoLight(entity);
 		vo.setEnabled(locator.isEnabled(entity.getId()));
+		applyPlugin(vo, entity, locator);
 		return vo;
 	}
 

--- a/plugin-core/src/test/java/org/ligoj/app/resource/node/NodeHelperTest.java
+++ b/plugin-core/src/test/java/org/ligoj/app/resource/node/NodeHelperTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under MIT (https://github.com/ligoj/ligoj/blob/master/LICENSE)
+ */
+package org.ligoj.app.resource.node;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.ligoj.app.api.ServicePlugin;
+import org.ligoj.app.model.Node;
+import org.ligoj.app.resource.ServicePluginLocator;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+/**
+ * Test class of {@link NodeHelper}, focused on the plugin-derived
+ * {@code preferredColor} enrichment applied by {@code applyPlugin}.
+ */
+class NodeHelperTest {
+
+	private static final String NODE_ID = "service:test:tool";
+	private static final String PARENT_ID = "service:test";
+
+	private Node newNode() {
+		return newNode(NODE_ID, "Test tool");
+	}
+
+	private Node newNode(final String id, final String name) {
+		final var entity = new Node();
+		entity.setId(id);
+		entity.setName(name);
+		return entity;
+	}
+
+	/**
+	 * Build a locator stubbing the given plugin for a single node id.
+	 */
+	private void stub(final ServicePluginLocator locator, final String id, final ServicePlugin plugin) {
+		Mockito.when(locator.getResource(ArgumentMatchers.eq(id), ArgumentMatchers.eq(ServicePlugin.class)))
+				.thenReturn(plugin);
+	}
+
+	private ServicePlugin pluginWithColor(final String color) {
+		final var plugin = Mockito.mock(ServicePlugin.class);
+		Mockito.when(plugin.getPreferredColor()).thenReturn(color);
+		return plugin;
+	}
+
+	private ServicePluginLocator locatorReturning(final ServicePlugin plugin) {
+		final var locator = Mockito.mock(ServicePluginLocator.class);
+		Mockito.when(locator.getResource(ArgumentMatchers.eq(NODE_ID), ArgumentMatchers.eq(ServicePlugin.class)))
+				.thenReturn(plugin);
+		return locator;
+	}
+
+	@Test
+	void toVoFillsPreferredColorFromPlugin() {
+		final var plugin = Mockito.mock(ServicePlugin.class);
+		Mockito.when(plugin.getPreferredColor()).thenReturn("#0052CC");
+
+		final var vo = NodeHelper.toVo(newNode(), locatorReturning(plugin));
+
+		Assertions.assertEquals("#0052CC", vo.getPreferredColor());
+	}
+
+	@Test
+	void toVoKeepsPreferredColorNullWhenPluginAbsent() {
+		final var vo = NodeHelper.toVo(newNode(), locatorReturning(null));
+
+		Assertions.assertNull(vo.getPreferredColor());
+	}
+
+	@Test
+	void toVoKeepsPreferredColorNullWhenPluginDeclaresNull() {
+		// Anonymous plugin relying on the default getPreferredColor() == null
+		final ServicePlugin plugin = () -> NODE_ID;
+
+		final var vo = NodeHelper.toVo(newNode(), locatorReturning(plugin));
+
+		Assertions.assertNull(vo.getPreferredColor());
+	}
+
+	@Test
+	void toVoLightAndToVoParameterAlsoFillPreferredColor() {
+		final var plugin = Mockito.mock(ServicePlugin.class);
+		Mockito.when(plugin.getPreferredColor()).thenReturn("#0052CC");
+		final var locator = locatorReturning(plugin);
+
+		Assertions.assertEquals("#0052CC", NodeHelper.toVoLight(newNode(), locator).getPreferredColor());
+
+		final var rows = new java.util.ArrayList<Object[]>();
+		rows.add(new Object[] { newNode(), null });
+		Assertions.assertEquals("#0052CC",
+				NodeHelper.toVoParameters(rows, locator).get(NODE_ID).getPreferredColor());
+	}
+
+	@Test
+	void toVoInheritsPreferredColorFromParent() {
+		final var child = newNode();
+		child.setRefined(newNode(PARENT_ID, "Test service"));
+
+		final var locator = Mockito.mock(ServicePluginLocator.class);
+		// Leaf tool declares no color, parent service does.
+		stub(locator, NODE_ID, pluginWithColor(null));
+		stub(locator, PARENT_ID, pluginWithColor("#0052CC"));
+
+		final var vo = NodeHelper.toVo(child, locator);
+
+		Assertions.assertEquals("#0052CC", vo.getPreferredColor());
+	}
+
+	@Test
+	void toVoChildPreferredColorOverridesParent() {
+		final var child = newNode();
+		child.setRefined(newNode(PARENT_ID, "Test service"));
+
+		final var locator = Mockito.mock(ServicePluginLocator.class);
+		// Leaf tool overrides the color declared by its parent service.
+		stub(locator, NODE_ID, pluginWithColor("#FF0000"));
+		stub(locator, PARENT_ID, pluginWithColor("#0052CC"));
+
+		final var vo = NodeHelper.toVo(child, locator);
+
+		Assertions.assertEquals("#FF0000", vo.getPreferredColor());
+	}
+}


### PR DESCRIPTION
## Context

The Ligoj dashboard now displays each tool as a card with a preferred color (see ligoj/plugin-ui#15). The PR that implemented the cards (ligoj/plugin-ui#27) used a frontend-only fallback (PNG canvas extraction) because no API existed to let a plugin declare its color.

This PR introduces the data model evolution mentioned in the original issue ("Each card has a preferred color. Either guessed from the SVG icon of the tool, either provided (need data model evolution) by the plugin"). It is the backend foundation for the cleaner "plugin-provided color" path.

## Changes

- `ServicePlugin#getPreferredColor()` default method returning `null` — opt-in, zero breaking change
- `NodeVo#preferredColor` field exposed in the REST payload
- `NodeHelper#applyPlugin(vo, entity, locator)` invoked from the three locator-aware variants (`toVo`, `toVoLight`, `toVoParameter`)
- `NodeHelper#resolvePreferredColor(entity, locator)` walks the parent chain via `Node#getRefined()` so a color declared at the service level (e.g. `service:id`) is inherited by its tools (e.g. `service:id:ldap`); leaf takes precedence over ancestors
- Updated `ServicePluginTest` (default null check)
- New `NodeHelperTest`: 6 tests covering the three variants, null cases, parent inheritance, child override priority

## Design rationale

### Why on `ServicePlugin` (not `ToolPlugin` or `FeaturePlugin`)

The color is **static branding metadata**, semantically closer to `getName()`/`getVendor()` on `FeaturePlugin` than to runtime methods like `checkStatus(...)` on `ToolPlugin`. Placing it on `ToolPlugin` would have excluded service-only nodes (`service:id`, `service:prov`, ...) from declaring a color. Placing it on `FeaturePlugin` would be more orthogonal but lives in the `ligoj-bootstrap` repository, requiring an additional coordinated release. `ServicePlugin` is the pragmatic middle ground that covers both service and tool plugins without crossing repository boundaries.

### Why factor `applyPlugin` across the three `toVo*` variants

`NodeHelper` exposes three locator-aware variants consumed by different REST endpoints (`findById`, `findAll`, parameter-aware lookups). A factored helper guarantees the color is filled regardless of which endpoint the consumer hits, with no logic duplication. Variants without a locator (`toVo(entity)`, ...) are intentionally left untouched: no locator means no plugin resolution, which is consistent with their current contract.

### Why walk up the parent chain manually

`locator.getResource(id, ServicePlugin.class)` already walks the parent chain to *find* a plugin, but returns the leaf's own value (not a composed inheritance). For colors specifically, that means a service-level color declared on `IdentityResource` (`service:id`) would not bubble down to its tool nodes (`service:id:ldap`) without an explicit walk-up. The explicit walk-up keeps the API ergonomic: a single override on the parent service covers all its tools by default, while individual tools can still override locally (leaf-first priority). This was validated end-to-end at runtime.

### Why a `null` default and how Jackson handles it

A `null` default keeps backward compatibility intact: every existing plugin remains valid without modification. Jackson's default configuration on Ligoj omits null fields from the JSON payload (verified at runtime via `GET /rest/node/service:id`), so consumers that don't yet know about `preferredColor` see no change in the API surface. The field appears in the payload only when a plugin in the chain declares a non-null value.

## Backward compatibility

- Default `null` return on `ServicePlugin#getPreferredColor()` → no existing plugin needs to change
- Walk-up resolves a color only when at least one plugin in the chain declares one
- Jackson omits null fields → no change in the existing JSON contract
- No version bump needed (work fits within the already-open `4.2.3-SNAPSHOT`)

## Tests

`mvn install`: **487 tests passed**, 0 failed, 0 skipped (+6 vs. master).

End-to-end runtime verified locally:
1. Override on `service:id` (Identity) returns the declared color via `GET /rest/node/service:id`
2. Tool `service:id:ldap` inherits the parent color via `GET /rest/node/service:id:ldap` (walk-up)

## Follow-up PRs

- `ligoj/ligoj` (host): `NodeIcon.vue` reads `node.preferredColor` and uses it as the card accent color
- Tool plugins: override `getPreferredColor()` with the brand color (e.g. `#0052CC` for Jira, `#FF9900` for AWS)
