### PR TITLE
feat(core): add UserLog model and REST resource for browser error logging

### DIFF
--- a/plugin-core/src/main/java/org/ligoj/app/dao/UserLogRepository.java
+++ b/plugin-core/src/main/java/org/ligoj/app/dao/UserLogRepository.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under MIT (https://github.com/ligoj/ligoj/blob/master/LICENSE)
+ */
+package org.ligoj.app.dao;
+
+import org.ligoj.app.model.UserLog;
+import org.ligoj.bootstrap.core.dao.RestRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+
+/**
+ * {@link UserLog} repository.
+ */
+public interface UserLogRepository extends RestRepository<UserLog, Integer> {
+
+	/**
+	 * Return all user logs within the given date range. The caller is expected to widen the range to cover the
+	 * "no bound" cases (see {@link org.ligoj.app.resource.log.UserLogResource}): both bounds are always provided, which
+	 * keeps the generated statement portable (some databases cannot resolve the type of a bare {@code NULL} bind
+	 * parameter).
+	 *
+	 * @param from Lower bound (inclusive).
+	 * @param to   Upper bound (inclusive).
+	 * @param page The pagination and sort.
+	 * @return The matching page of user logs.
+	 */
+	@Query("FROM UserLog u WHERE u.date >= :from AND u.date <= :to")
+	Page<UserLog> findAllByDate(@Param("from") Instant from, @Param("to") Instant to, Pageable page);
+}

--- a/plugin-core/src/main/java/org/ligoj/app/model/UserLog.java
+++ b/plugin-core/src/main/java/org/ligoj/app/model/UserLog.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under MIT (https://github.com/ligoj/ligoj/blob/master/LICENSE)
+ */
+package org.ligoj.app.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+import org.ligoj.bootstrap.core.model.AbstractPersistable;
+
+import java.time.Instant;
+
+/**
+ * A browser side error logged by an authenticated user. This is a user-scoped log (not node-scoped): each entry is
+ * owned by the user that produced it.
+ */
+@Getter
+@Setter
+@Entity
+@Table(name = "LIGOJ_USER_LOG")
+public class UserLog extends AbstractPersistable<Integer> {
+
+	/**
+	 * Login of the user owning this log. Filled by the server from the security context.
+	 * <p>
+	 * The column is named {@code user_login} since {@code USER} is a reserved keyword on several databases (H2,
+	 * PostgreSQL, ...).
+	 */
+	@Length(max = 100)
+	@Column(name = "user_login")
+	private String user;
+
+	/**
+	 * Date of the error. Filled by the server.
+	 */
+	private Instant date;
+
+	/**
+	 * Error message. Truncated to 2000 characters by the server.
+	 */
+	@Column(length = 2000)
+	private String message;
+
+	/**
+	 * Path (without domain) of the page where the error occurred.
+	 */
+	@Length(max = 512)
+	private String url;
+}

--- a/plugin-core/src/main/java/org/ligoj/app/resource/log/UserLogEditionVo.java
+++ b/plugin-core/src/main/java/org/ligoj/app/resource/log/UserLogEditionVo.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under MIT (https://github.com/ligoj/ligoj/blob/master/LICENSE)
+ */
+package org.ligoj.app.resource.log;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Body of the POST endpoint used by an authenticated user to log a browser side error.
+ */
+@Getter
+@Setter
+public class UserLogEditionVo {
+
+	/**
+	 * Error message. Truncated to 2000 characters by the server.
+	 */
+	private String message;
+
+	/**
+	 * Path (without domain) of the page where the error occurred.
+	 */
+	private String url;
+}

--- a/plugin-core/src/main/java/org/ligoj/app/resource/log/UserLogResource.java
+++ b/plugin-core/src/main/java/org/ligoj/app/resource/log/UserLogResource.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under MIT (https://github.com/ligoj/ligoj/blob/master/LICENSE)
+ */
+package org.ligoj.app.resource.log;
+
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriInfo;
+import org.apache.commons.lang3.StringUtils;
+import org.ligoj.app.dao.UserLogRepository;
+import org.ligoj.app.model.UserLog;
+import org.ligoj.bootstrap.core.json.PaginationJson;
+import org.ligoj.bootstrap.core.json.TableItem;
+import org.ligoj.bootstrap.core.security.SecurityHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * User log resource. Authenticated users log their own browser side errors with the POST endpoint, while the listing is
+ * restricted to administrators.
+ */
+@Path("/user-log")
+@Service
+@Produces(MediaType.APPLICATION_JSON)
+@Transactional
+public class UserLogResource {
+
+	@Autowired
+	private SecurityHelper securityHelper;
+
+	@Autowired
+	private UserLogRepository repository;
+
+	@Autowired
+	private PaginationJson paginationJson;
+
+	/**
+	 * Ordered columns.
+	 */
+	private static final Map<String, String> ORDERED_COLUMNS = Map.of("id", "id", "user", "user", "date", "date",
+			"message", "message", "url", "url");
+
+	/**
+	 * Non-string ordered columns: no case-insensitive ({@code lower()}) wrapping, which is invalid on numeric/temporal
+	 * types.
+	 */
+	private static final Set<String> CASE_SENSITIVE_COLUMNS = Set.of("id", "date");
+
+	/**
+	 * Lower bound used when no <code>from</code> is provided.
+	 */
+	private static final Instant MIN_DATE = Instant.EPOCH;
+
+	/**
+	 * Upper bound used when no <code>to</code> is provided. Stays within the range supported by SQL timestamps.
+	 */
+	private static final Instant MAX_DATE = Instant.parse("9999-12-31T23:59:59Z");
+
+	/**
+	 * Log a browser side error for the current user. Open to any authenticated user: the login and the date are filled
+	 * by the server, so a user can only log on its own behalf.
+	 *
+	 * @param vo The error to log.
+	 */
+	@POST
+	public void log(final UserLogEditionVo vo) {
+		final var entity = new UserLog();
+		entity.setUser(securityHelper.getLogin());
+		entity.setDate(Instant.now());
+		entity.setMessage(StringUtils.truncate(vo.getMessage(), 2000));
+		entity.setUrl(vo.getUrl());
+		repository.saveAndFlush(entity);
+	}
+
+	/**
+	 * Retrieve all user logs with pagination and an optional date range. Restricted to administrators.
+	 *
+	 * @param uriInfo Pagination data.
+	 * @param from    Optional lower bound (inclusive) as epoch milliseconds.
+	 * @param to      Optional upper bound (inclusive) as epoch milliseconds.
+	 * @return All matching logs with pagination.
+	 */
+	@GET
+	@PreAuthorize("hasAuthority('ADMIN')")
+	public TableItem<UserLogVo> findAll(@Context final UriInfo uriInfo, @QueryParam("from") final Long from,
+			@QueryParam("to") final Long to) {
+		final var page = paginationJson.getPageRequest(uriInfo, ORDERED_COLUMNS, CASE_SENSITIVE_COLUMNS);
+		final var result = repository.findAllByDate(from == null ? MIN_DATE : Instant.ofEpochMilli(from),
+				to == null ? MAX_DATE : Instant.ofEpochMilli(to), page);
+		return paginationJson.applyPagination(uriInfo, result, this::toVo);
+	}
+
+	/**
+	 * Converter from {@link UserLog} to {@link UserLogVo}.
+	 *
+	 * @param entity The entity to convert.
+	 * @return The corresponding business object.
+	 */
+	private UserLogVo toVo(final UserLog entity) {
+		final var vo = new UserLogVo();
+		vo.setId(entity.getId());
+		vo.setUser(entity.getUser());
+		vo.setDate(entity.getDate());
+		vo.setMessage(entity.getMessage());
+		vo.setUrl(entity.getUrl());
+		return vo;
+	}
+}

--- a/plugin-core/src/main/java/org/ligoj/app/resource/log/UserLogVo.java
+++ b/plugin-core/src/main/java/org/ligoj/app/resource/log/UserLogVo.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under MIT (https://github.com/ligoj/ligoj/blob/master/LICENSE)
+ */
+package org.ligoj.app.resource.log;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+/**
+ * A user log business object returned by the GET endpoint.
+ */
+@Getter
+@Setter
+public class UserLogVo {
+
+	/**
+	 * Log identifier.
+	 */
+	private Integer id;
+
+	/**
+	 * Login of the user owning this log.
+	 */
+	private String user;
+
+	/**
+	 * Date of the error.
+	 */
+	private Instant date;
+
+	/**
+	 * Error message.
+	 */
+	private String message;
+
+	/**
+	 * Path (without domain) of the page where the error occurred.
+	 */
+	private String url;
+}

--- a/plugin-core/src/test/java/org/ligoj/app/resource/log/UserLogResourceTest.java
+++ b/plugin-core/src/test/java/org/ligoj/app/resource/log/UserLogResourceTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under MIT (https://github.com/ligoj/ligoj/blob/master/LICENSE)
+ */
+package org.ligoj.app.resource.log;
+
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.ligoj.app.AbstractAppTest;
+import org.ligoj.app.dao.UserLogRepository;
+import org.ligoj.app.model.UserLog;
+import org.ligoj.bootstrap.core.security.SecurityHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * {@link UserLogResource} test cases.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(locations = "classpath:/META-INF/spring/application-context-test.xml")
+@Rollback
+@Transactional
+class UserLogResourceTest extends AbstractAppTest {
+
+	@Autowired
+	private UserLogResource resource;
+
+	@Autowired
+	private UserLogRepository repository;
+
+	@Test
+	void log() {
+		initSpringSecurityContext("alice");
+		final var count = repository.count();
+
+		final var vo = new UserLogEditionVo();
+		vo.setMessage("Boom");
+		vo.setUrl("/home");
+		resource.log(vo);
+
+		Assertions.assertEquals(count + 1, repository.count());
+		final var entity = repository.findAll().getFirst();
+		Assertions.assertEquals("alice", entity.getUser());
+		Assertions.assertEquals("Boom", entity.getMessage());
+		Assertions.assertEquals("/home", entity.getUrl());
+		Assertions.assertNotNull(entity.getDate());
+		Assertions.assertTrue(entity.getDate().plusSeconds(5).isAfter(Instant.now()));
+	}
+
+	@Test
+	void logTruncatesMessage() {
+		initSpringSecurityContext("alice");
+		final var vo = new UserLogEditionVo();
+		vo.setMessage("x".repeat(2500));
+		vo.setUrl("/home");
+		resource.log(vo);
+
+		final var entity = repository.findAll().getFirst();
+		Assertions.assertEquals(2000, entity.getMessage().length());
+	}
+
+	@Test
+	void findAll() {
+		initSpringSecurityContext(DEFAULT_USER, new SimpleGrantedAuthority(SecurityHelper.ADMIN));
+		final var now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+		newLog("alice", now.minus(2, ChronoUnit.DAYS), "old");
+		newLog("bob", now, "recent");
+
+		final var uriInfo = newUriInfoDesc("date");
+		final var result = resource.findAll(uriInfo, null, null);
+
+		Assertions.assertEquals(2, result.getData().size());
+		// Sorted by date descending: most recent first
+		Assertions.assertEquals("recent", result.getData().get(0).getMessage());
+		Assertions.assertEquals("bob", result.getData().get(0).getUser());
+		Assertions.assertEquals("/page", result.getData().get(0).getUrl());
+		Assertions.assertNotNull(result.getData().get(0).getId());
+		Assertions.assertEquals("old", result.getData().get(1).getMessage());
+	}
+
+	@Test
+	void findAllFilterFrom() {
+		initSpringSecurityContext(DEFAULT_USER, new SimpleGrantedAuthority(SecurityHelper.ADMIN));
+		final var now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+		newLog("alice", now.minus(2, ChronoUnit.DAYS), "old");
+		newLog("bob", now, "recent");
+
+		// Keep only logs at or after yesterday
+		final var from = now.minus(1, ChronoUnit.DAYS).toEpochMilli();
+		final var result = resource.findAll(newUriInfoDesc("date"), from, null);
+
+		Assertions.assertEquals(1, result.getData().size());
+		Assertions.assertEquals("recent", result.getData().getFirst().getMessage());
+	}
+
+	@Test
+	void findAllFilterTo() {
+		initSpringSecurityContext(DEFAULT_USER, new SimpleGrantedAuthority(SecurityHelper.ADMIN));
+		final var now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+		newLog("alice", now.minus(2, ChronoUnit.DAYS), "old");
+		newLog("bob", now, "recent");
+
+		// Keep only logs at or before yesterday
+		final var to = now.minus(1, ChronoUnit.DAYS).toEpochMilli();
+		final var result = resource.findAll(newUriInfoDesc("date"), null, to);
+
+		Assertions.assertEquals(1, result.getData().size());
+		Assertions.assertEquals("old", result.getData().getFirst().getMessage());
+	}
+
+	private void newLog(final String user, final Instant date, final String message) {
+		final var entity = new UserLog();
+		entity.setUser(user);
+		entity.setDate(date);
+		entity.setMessage(message);
+		entity.setUrl("/page");
+		em.persist(entity);
+		em.flush();
+	}
+}


### PR DESCRIPTION
## Context
Backend part of ligoj/plugin-ui#34 (record browser-side errors and expose them in
an admin "User logs" view). This PR adds the data model and the REST resource in
plugin-core, as the issue specifies. The front-end capture and the admin UI come
in separate PRs (host + plugin-ui).

## What it does
- `UserLog` entity → table `LIGOJ_USER_LOG`, created automatically by Hibernate
  (`jpa.hbm2ddl=update`), so no SQL migration is shipped.
- `UserLogResource` (`/user-log`):
  - `POST` records one error; the server stamps the login (`SecurityHelper.getLogin()`)
    and the date, so a user can only log on its own behalf. Body: `{ message, url }`.
  - `GET` returns the logs paginated, newest first, with an optional `from`/`to`
    date range (epoch ms). Restricted to administrators.

## Design decisions (and why)
- New dedicated entity rather than reusing `Event`: `Event` is node/subscription
  scoped; this log is user-scoped with different columns, so a clean entity is simpler.
- Column `user` mapped to `user_login`: `USER` is a reserved keyword on several
  databases (H2/HSQLDB/PostgreSQL) and breaks the generated DDL otherwise.
- `message` capped at 2000 chars (truncated server-side), `url` at 512 and stored
  path-only (no domain) — consistent with the bug-report dialog (plugin-ui#33).
- Date filter uses explicit bounds (EPOCH .. 9999) instead of `:param IS NULL OR …`:
  the latter fails on HSQLDB (untyped NULL parameter); the bounds are portable
  across all databases and semantically equivalent to "no bound".
- Sorting: `id` and `date` are passed as case-sensitive columns so pagination does
  not wrap them in `lower()` (invalid on numeric/temporal types).

## Security
- `GET` is admin-only by two mechanisms: Ligoj's RBAC filter is default-deny (no
  `USER` authorization pattern covers `/user-log`, so only `ADMIN` `.*` matches),
  AND an explicit `@PreAuthorize("hasAuthority('ADMIN')")` on the method.
- `POST` is meant to be open to any authenticated user. That requires ONE line in
  the host authorization seed (`ligoj/app-api/.../system-authorization.csv`):
  `POST;^rest/user-log.*;API;USER`. That change lives in the host repo and ships
  with the front-end capture PR — NOT here.
- Note: an open POST is a potential spam vector; the front-end will throttle/dedupe,
  and a server-side rate limit could be added later if needed.

## Integration note (for the release process)
plugin-core is consumed by the host via a pinned `api.version`. Going live therefore
needs a plugin-core release and a host `api.version` bump — a release-management step
on your side. Locally this was validated by bumping `api.version` to the SNAPSHOT
(not committed): table auto-created, POST → 204, GET → 200 returning the row.

## What's not in this PR
- Front-end error capture (host) + the `POST` authorization line.
- The admin "User logs" UI (plugin-ui).

## Tests
`mvn -pl plugin-core -am install` → BUILD SUCCESS, 370 tests green incl. 5 new
`UserLogResourceTest` (create, truncation, date filter, sort date desc).

Feedback very welcome — happy to adjust the contract (paths, payload, naming) to
match how you'd like the model/resource shaped in plugin-core.