### PR TITLE
feat(task): system long-task status REST API

### DIFF
--- a/plugin-core/src/main/java/org/ligoj/app/dao/task/LongTaskSubscriptionRepository.java
+++ b/plugin-core/src/main/java/org/ligoj/app/dao/task/LongTaskSubscriptionRepository.java
@@ -3,6 +3,9 @@
  */
 package org.ligoj.app.dao.task;
 
+import java.util.List;
+
+import org.ligoj.app.dao.ProjectRepository;
 import org.ligoj.app.model.AbstractLongTask;
 import org.ligoj.app.model.Subscription;
 import org.springframework.data.jpa.repository.Query;
@@ -13,6 +16,7 @@ import org.springframework.data.repository.NoRepositoryBean;
  *
  * @param <T> Type of task entity.
  */
+@SuppressWarnings("ALL")
 @NoRepositoryBean
 public interface LongTaskSubscriptionRepository<T extends AbstractLongTask<Subscription, Integer>>
 		extends LongTaskRepository<T, Subscription, Integer> {
@@ -20,5 +24,17 @@ public interface LongTaskSubscriptionRepository<T extends AbstractLongTask<Subsc
 	@Override
 	@Query("FROM #{#entityName} t WHERE t.locked.id = :locked AND t.end IS NULL")
 	T findNotFinishedByLocked(Integer locked);
+
+	/**
+	 * Return all tasks whose locked subscription belongs to a project visible by the given user. Mirror of the node
+	 * repository's {@code findAllVisible}, scoped through the subscription's project visibility.
+	 *
+	 * @param user The current principal user.
+	 * @return The visible tasks for the current principal user.
+	 */
+	@SuppressWarnings("unused")
+	@Query("SELECT DISTINCT i FROM #{#entityName} i INNER JOIN i.locked s INNER JOIN s.project p"
+			+ " LEFT JOIN p.cacheGroups AS cpg LEFT JOIN cpg.group AS cg WHERE " + ProjectRepository.VISIBLE_PROJECTS)
+	List<T> findAllVisible(String user);
 
 }

--- a/plugin-core/src/main/java/org/ligoj/app/resource/task/LockedRefVo.java
+++ b/plugin-core/src/main/java/org/ligoj/app/resource/task/LockedRefVo.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under MIT (https://github.com/ligoj/ligoj/blob/master/LICENSE)
+ */
+package org.ligoj.app.resource.task;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Reference to the entity locked by a task, with just enough data for the UI to render it (a node icon, or a
+ * subscription with its project link).
+ */
+@Getter
+@Setter
+public class LockedRefVo {
+
+	/**
+	 * Kind of locked reference.
+	 */
+	private TaskStatusType type;
+
+	/**
+	 * Node identifier. Set for a node task (the locked node) and for a subscription task (the subscription's service
+	 * node, used for the icon). {@code null} otherwise.
+	 */
+	private String node;
+
+	/**
+	 * Subscription identifier. Set only for a subscription task.
+	 */
+	private Integer subscription;
+
+	/**
+	 * Owning project. Set only for a subscription task.
+	 */
+	private ProjectRef project;
+
+	/**
+	 * Minimal project reference.
+	 *
+	 * @param id   The project identifier.
+	 * @param name The project name.
+	 */
+	public record ProjectRef(int id, String name) {
+	}
+
+	/**
+	 * Build a node reference.
+	 *
+	 * @param node The locked node identifier.
+	 * @return the reference.
+	 */
+	public static LockedRefVo ofNode(final String node) {
+		final var ref = new LockedRefVo();
+		ref.type = TaskStatusType.NODE;
+		ref.node = node;
+		return ref;
+	}
+
+	/**
+	 * Build a subscription reference.
+	 *
+	 * @param subscription The locked subscription identifier.
+	 * @param node         The subscription's service node identifier.
+	 * @param projectId    The owning project identifier.
+	 * @param projectName  The owning project name.
+	 * @return the reference.
+	 */
+	public static LockedRefVo ofSubscription(final int subscription, final String node, final int projectId,
+			final String projectName) {
+		final var ref = new LockedRefVo();
+		ref.type = TaskStatusType.SUBSCRIPTION;
+		ref.subscription = subscription;
+		ref.node = node;
+		ref.project = new ProjectRef(projectId, projectName);
+		return ref;
+	}
+
+	/**
+	 * Build a reference for an unclassified runner.
+	 *
+	 * @return the reference.
+	 */
+	public static LockedRefVo ofOther() {
+		final var ref = new LockedRefVo();
+		ref.type = TaskStatusType.OTHER;
+		return ref;
+	}
+}

--- a/plugin-core/src/main/java/org/ligoj/app/resource/task/LongTaskRunnerVo.java
+++ b/plugin-core/src/main/java/org/ligoj/app/resource/task/LongTaskRunnerVo.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under MIT (https://github.com/ligoj/ligoj/blob/master/LICENSE)
+ */
+package org.ligoj.app.resource.task;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Descriptor of a {@link org.ligoj.app.resource.plugin.LongTaskRunner} bean, with its visible task statistics.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+public class LongTaskRunnerVo {
+
+	/**
+	 * Stable runner key: the Spring bean name. Used as path parameter to list its tasks.
+	 */
+	private String key;
+
+	/**
+	 * Human-readable label: the task entity simple class name (e.g. {@code ImportCatalogStatus}).
+	 */
+	private String label;
+
+	/**
+	 * Runner classification.
+	 */
+	private TaskStatusType type;
+
+	/**
+	 * Task counters by status, over the visible tasks of the current principal.
+	 */
+	private TaskStatsVo stats;
+}

--- a/plugin-core/src/main/java/org/ligoj/app/resource/task/TaskStatsVo.java
+++ b/plugin-core/src/main/java/org/ligoj/app/resource/task/TaskStatsVo.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under MIT (https://github.com/ligoj/ligoj/blob/master/LICENSE)
+ */
+package org.ligoj.app.resource.task;
+
+/**
+ * Per-runner task counters, by derived status. Designed to feed a progress bar.
+ * {@code running + succeeded + failed == total}.
+ *
+ * @param total     Total amount of visible tasks.
+ * @param running   Amount of running tasks ({@code end} is {@code null}).
+ * @param succeeded Amount of finished tasks without the {@code failed} flag.
+ * @param failed    Amount of finished tasks with the {@code failed} flag.
+ */
+public record TaskStatsVo(int total, int running, int succeeded, int failed) {
+}

--- a/plugin-core/src/main/java/org/ligoj/app/resource/task/TaskStatus.java
+++ b/plugin-core/src/main/java/org/ligoj/app/resource/task/TaskStatus.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under MIT (https://github.com/ligoj/ligoj/blob/master/LICENSE)
+ */
+package org.ligoj.app.resource.task;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Derived status of a {@link org.ligoj.app.model.AbstractLongTask}.
+ * <ul>
+ * <li>{@link #RUNNING}: not finished yet ({@code end} is {@code null}).</li>
+ * <li>{@link #FAILED}: finished with the {@code failed} flag set.</li>
+ * <li>{@link #SUCCEEDED}: finished without the {@code failed} flag.</li>
+ * </ul>
+ */
+public enum TaskStatus {
+
+	/**
+	 * Task is still running ({@code end} is {@code null}).
+	 */
+	RUNNING,
+
+	/**
+	 * Task finished successfully.
+	 */
+	SUCCEEDED,
+
+	/**
+	 * Task finished with a failure.
+	 */
+	FAILED;
+
+	/**
+	 * Lower-case representation used in the JSON payload.
+	 *
+	 * @return the lower-case name.
+	 */
+	@JsonValue
+	public String toJson() {
+		return name().toLowerCase();
+	}
+
+	/**
+	 * Parse a nullable/blank filter value into a status (case-insensitive).
+	 *
+	 * @param value the raw query value.
+	 * @return the matching status, or {@code null} when blank.
+	 */
+	public static TaskStatus parse(final String value) {
+		return value == null || value.isBlank() ? null : valueOf(value.trim().toUpperCase());
+	}
+}

--- a/plugin-core/src/main/java/org/ligoj/app/resource/task/TaskStatusResource.java
+++ b/plugin-core/src/main/java/org/ligoj/app/resource/task/TaskStatusResource.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed under MIT (https://github.com/ligoj/ligoj/blob/master/LICENSE)
+ */
+package org.ligoj.app.resource.task;
+
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.ligoj.app.dao.task.LongTaskNodeRepository;
+import org.ligoj.app.dao.task.LongTaskSubscriptionRepository;
+import org.ligoj.app.model.AbstractLongTask;
+import org.ligoj.app.model.AbstractLongTaskNode;
+import org.ligoj.app.model.AbstractLongTaskSubscription;
+import org.ligoj.app.resource.node.LongTaskRunnerNode;
+import org.ligoj.app.resource.plugin.LongTaskRunner;
+import org.ligoj.app.resource.subscription.LongTaskRunnerSubscription;
+import org.ligoj.bootstrap.core.json.PaginationJson;
+import org.ligoj.bootstrap.core.json.TableItem;
+import org.ligoj.bootstrap.core.security.SecurityHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+/**
+ * Admin-only, read-only diagnostic resource exposing all {@link LongTaskRunner} beans (grouped as node /
+ * subscription / other), with per-runner status statistics and a paginated, filterable task list.
+ * <p>
+ * Admin-only is enforced by the default RBAC rule ({@code ;.*;API;ADMIN}); no authorization entry is required.
+ */
+@Path("system/task")
+@Service
+@Produces(MediaType.APPLICATION_JSON)
+@Transactional
+public class TaskStatusResource {
+
+	/**
+	 * DataTables column to ORM/VO property mapping for the task list sort.
+	 */
+	private static final Map<String, String> ORM_MAPPING = Map.of("id", "id", "author", "author", "start", "start",
+			"end", "end", "status", "status");
+
+	@Autowired
+	protected ApplicationContext applicationContext;
+
+	@Autowired
+	protected SecurityHelper securityHelper;
+
+	@Autowired
+	protected PaginationJson paginationJson;
+
+	/**
+	 * Return all {@link LongTaskRunner} beans, keyed by Spring bean name.
+	 *
+	 * @return the runner beans.
+	 */
+	@SuppressWarnings("rawtypes")
+	protected Map<String, LongTaskRunner> getRunners() {
+		return applicationContext.getBeansOfType(LongTaskRunner.class);
+	}
+
+	/**
+	 * List all runners with their visible-task statistics.
+	 *
+	 * @return the runners, ordered by key.
+	 */
+	@GET
+	public List<LongTaskRunnerVo> findAll() {
+		final var user = securityHelper.getLogin();
+		return getRunners().entrySet().stream().map(e -> toRunnerVo(e.getKey(), e.getValue(), user))
+				.sorted(Comparator.comparing(LongTaskRunnerVo::getKey)).toList();
+	}
+
+	/**
+	 * List the visible tasks of a single runner, paginated, optionally filtered by status, sorted by start date
+	 * descending by default. Filtering / sorting / pagination are applied in memory (at most one task per locked
+	 * entity).
+	 *
+	 * @param key          The runner bean name.
+	 * @param uriInfo      DataTables pagination parameters.
+	 * @param statusFilter Optional status filter ({@code running}, {@code succeeded} or {@code failed}).
+	 * @return the matching tasks.
+	 */
+	@GET
+	@Path("{key}")
+	public TableItem<TaskVo> findTasks(@PathParam("key") final String key, @Context final UriInfo uriInfo,
+			@QueryParam("status") final String statusFilter) {
+		final var runner = getRunners().get(key);
+		if (runner == null) {
+			throw new NotFoundException("Unknown task runner: " + key);
+		}
+		final var status = TaskStatus.parse(statusFilter);
+		final var user = securityHelper.getLogin();
+		final var filtered = visibleTasks(runner, user).stream().map(this::toTaskVo)
+				.filter(v -> status == null || v.getStatus() == status).toList();
+
+		// In-memory sort + pagination using the DataTables page request.
+		final var pageRequest = paginationJson.getPageRequest(uriInfo, ORM_MAPPING);
+		final var sorted = filtered.stream().sorted(comparator(pageRequest.getSort())).toList();
+		final var from = (int) Math.min(pageRequest.getOffset(), sorted.size());
+		final var to = Math.min(from + pageRequest.getPageSize(), sorted.size());
+		final var page = new PageImpl<>(sorted.subList(from, to), pageRequest, sorted.size());
+		return paginationJson.applyPagination(uriInfo, page, Function.identity());
+	}
+
+	/**
+	 * Resolve the visible tasks of a runner: node and subscription runners are user-scoped via their
+	 * {@code findAllVisible}; any other runner falls back to all its tasks (justified by the admin-only access).
+	 */
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	protected List<? extends AbstractLongTask<?, ?>> visibleTasks(final LongTaskRunner runner, final String user) {
+		if (runner instanceof LongTaskRunnerNode) {
+			return ((LongTaskNodeRepository) runner.getTaskRepository()).findAllVisible(user);
+		}
+		if (runner instanceof LongTaskRunnerSubscription) {
+			return ((LongTaskSubscriptionRepository) runner.getTaskRepository()).findAllVisible(user);
+		}
+		return runner.getTaskRepository().findAll();
+	}
+
+	/**
+	 * Build the runner descriptor and compute its statistics over the visible tasks.
+	 */
+	@SuppressWarnings("rawtypes")
+	protected LongTaskRunnerVo toRunnerVo(final String key, final LongTaskRunner runner, final String user) {
+		var running = 0;
+		var succeeded = 0;
+		var failed = 0;
+		final var tasks = visibleTasks(runner, user);
+		for (final var task : tasks) {
+			switch (status(task)) {
+			case RUNNING -> running++;
+			case SUCCEEDED -> succeeded++;
+			case FAILED -> failed++;
+			}
+		}
+		final var label = runner.newTask().get().getClass().getSimpleName();
+		return new LongTaskRunnerVo(key, label, type(runner), new TaskStatsVo(tasks.size(), running, succeeded, failed));
+	}
+
+	/**
+	 * Map a task entity to its VO.
+	 */
+	protected TaskVo toTaskVo(final AbstractLongTask<?, ?> task) {
+		final var vo = new TaskVo();
+		vo.setId(task.getId());
+		vo.setAuthor(task.getAuthor());
+		vo.setStart(task.getStart());
+		vo.setEnd(task.getEnd());
+		vo.setStatus(status(task));
+		vo.setLocked(lockedRef(task));
+		return vo;
+	}
+
+	/**
+	 * Build the locked entity reference for a task.
+	 */
+	protected LockedRefVo lockedRef(final AbstractLongTask<?, ?> task) {
+		if (task instanceof AbstractLongTaskNode node) {
+			return LockedRefVo.ofNode(node.getLocked().getId());
+		}
+		if (task instanceof AbstractLongTaskSubscription subscriptionTask) {
+			final var subscription = subscriptionTask.getLocked();
+			return LockedRefVo.ofSubscription(subscription.getId(), subscription.getNode().getId(),
+					subscription.getProject().getId(), subscription.getProject().getName());
+		}
+		return LockedRefVo.ofOther();
+	}
+
+	/**
+	 * Derive the status of a task: running ({@code end} null), failed (ended with the failed flag) or succeeded.
+	 */
+	protected TaskStatus status(final AbstractLongTask<?, ?> task) {
+		if (task.getEnd() == null) {
+			return TaskStatus.RUNNING;
+		}
+		return task.isFailed() ? TaskStatus.FAILED : TaskStatus.SUCCEEDED;
+	}
+
+	/**
+	 * Classify a runner by {@code instanceof}.
+	 */
+	@SuppressWarnings("rawtypes")
+	protected TaskStatusType type(final LongTaskRunner runner) {
+		if (runner instanceof LongTaskRunnerNode) {
+			return TaskStatusType.NODE;
+		}
+		if (runner instanceof LongTaskRunnerSubscription) {
+			return TaskStatusType.SUBSCRIPTION;
+		}
+		return TaskStatusType.OTHER;
+	}
+
+	/**
+	 * Build a comparator from the requested sort, defaulting to start date descending.
+	 */
+	protected Comparator<TaskVo> comparator(final Sort sort) {
+		Comparator<TaskVo> result = null;
+		for (final var order : sort) {
+			final var base = comparatorFor(order.getProperty());
+			final var directed = order.isDescending() ? base.reversed() : base;
+			result = result == null ? directed : result.thenComparing(directed);
+		}
+		return result == null
+				? Comparator.comparing(TaskVo::getStart, Comparator.nullsLast(Comparator.naturalOrder())).reversed()
+				: result;
+	}
+
+	/**
+	 * Ascending comparator for a single sortable property. Unknown properties fall back to the start date.
+	 */
+	protected Comparator<TaskVo> comparatorFor(final String property) {
+		return switch (property) {
+		case "id" -> Comparator.comparing(TaskVo::getId, Comparator.nullsLast(Comparator.naturalOrder()));
+		case "author" -> Comparator.comparing(TaskVo::getAuthor, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER));
+		case "end" -> Comparator.comparing(TaskVo::getEnd, Comparator.nullsLast(Comparator.naturalOrder()));
+		case "status" -> Comparator.comparing(t -> t.getStatus().name());
+		default -> Comparator.comparing(TaskVo::getStart, Comparator.nullsLast(Comparator.naturalOrder()));
+		};
+	}
+}

--- a/plugin-core/src/main/java/org/ligoj/app/resource/task/TaskStatusType.java
+++ b/plugin-core/src/main/java/org/ligoj/app/resource/task/TaskStatusType.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under MIT (https://github.com/ligoj/ligoj/blob/master/LICENSE)
+ */
+package org.ligoj.app.resource.task;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Kind of locked resource a {@link org.ligoj.app.resource.plugin.LongTaskRunner} operates on.
+ */
+public enum TaskStatusType {
+
+	/**
+	 * Runner locking a {@link org.ligoj.app.model.Node} (implements {@code LongTaskRunnerNode}).
+	 */
+	NODE,
+
+	/**
+	 * Runner locking a {@link org.ligoj.app.model.Subscription} (implements {@code LongTaskRunnerSubscription}).
+	 */
+	SUBSCRIPTION,
+
+	/**
+	 * Any other runner, not bound to a node nor a subscription.
+	 */
+	OTHER;
+
+	/**
+	 * Lower-case representation used in the JSON payload.
+	 *
+	 * @return the lower-case name.
+	 */
+	@JsonValue
+	public String toJson() {
+		return name().toLowerCase();
+	}
+}

--- a/plugin-core/src/main/java/org/ligoj/app/resource/task/TaskVo.java
+++ b/plugin-core/src/main/java/org/ligoj/app/resource/task/TaskVo.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under MIT (https://github.com/ligoj/ligoj/blob/master/LICENSE)
+ */
+package org.ligoj.app.resource.task;
+
+import java.util.Date;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * A single task row: the scalar fields of {@link org.ligoj.app.model.AbstractLongTask} plus the locked entity
+ * reference. Runner-specific fields are intentionally not exposed (they vary per runner).
+ */
+@Getter
+@Setter
+public class TaskVo {
+
+	/**
+	 * Task identifier.
+	 */
+	private Integer id;
+
+	/**
+	 * User who started the task.
+	 */
+	private String author;
+
+	/**
+	 * Start date.
+	 */
+	private Date start;
+
+	/**
+	 * End date, {@code null} while running.
+	 */
+	private Date end;
+
+	/**
+	 * Derived status.
+	 */
+	private TaskStatus status;
+
+	/**
+	 * Reference to the locked entity (node or subscription).
+	 */
+	private LockedRefVo locked;
+}

--- a/plugin-core/src/test/java/org/ligoj/app/resource/task/TaskStatusResourceTest.java
+++ b/plugin-core/src/test/java/org/ligoj/app/resource/task/TaskStatusResourceTest.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed under MIT (https://github.com/ligoj/ligoj/blob/master/LICENSE)
+ */
+package org.ligoj.app.resource.task;
+
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.ligoj.app.dao.TaskSampleNodeRepository;
+import org.ligoj.app.dao.TaskSampleSubscriptionRepository;
+import org.ligoj.app.model.Node;
+import org.ligoj.app.model.Subscription;
+import org.ligoj.app.model.TaskSampleNode;
+import org.ligoj.app.model.TaskSampleSubscription;
+import org.ligoj.app.resource.AbstractOrgTest;
+import org.ligoj.app.resource.node.TaskSampleNodeResource;
+import org.ligoj.app.resource.node.sample.BugTrackerResource;
+import org.ligoj.app.resource.subscription.TaskSampleSubscriptionResource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Test class of {@link TaskStatusResource}.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(locations = "classpath:/META-INF/spring/application-context-test.xml")
+@Rollback
+@Transactional
+class TaskStatusResourceTest extends AbstractOrgTest {
+
+	private static final String NODE_RUNNER = "taskSampleNodeResource";
+	private static final String SUBSCRIPTION_RUNNER = "taskSampleSubscriptionResource";
+
+	@Autowired
+	private TaskStatusResource resource;
+
+	@Autowired
+	private TaskSampleNodeRepository nodeRepository;
+
+	@Autowired
+	private TaskSampleSubscriptionRepository subscriptionRepository;
+
+	private int subscription;
+
+	@BeforeEach
+	void setUpRunners() {
+		subscription = getSubscription("MDA", BugTrackerResource.SERVICE_KEY);
+		// Register the sample runners as beans so getBeansOfType() discovers them.
+		registerRunner(NODE_RUNNER, TaskSampleNodeResource.class);
+		registerRunner(SUBSCRIPTION_RUNNER, TaskSampleSubscriptionResource.class);
+	}
+
+	@AfterEach
+	void tearDownRunners() {
+		destroyRunner(NODE_RUNNER);
+		destroyRunner(SUBSCRIPTION_RUNNER);
+	}
+
+	private DefaultListableBeanFactory beanFactory() {
+		return (DefaultListableBeanFactory) applicationContext.getAutowireCapableBeanFactory();
+	}
+
+	private void registerRunner(final String name, final Class<?> type) {
+		beanFactory().registerSingleton(name, beanFactory().createBean(type));
+	}
+
+	private void destroyRunner(final String name) {
+		if (beanFactory().containsSingleton(name)) {
+			beanFactory().destroySingleton(name);
+		}
+	}
+
+	private TaskSampleNode nodeTask(final String node, final long start, final Date end, final boolean failed) {
+		final var task = new TaskSampleNode();
+		task.setAuthor(DEFAULT_USER);
+		task.setData("d");
+		task.setStart(new Date(start));
+		task.setEnd(end);
+		task.setFailed(failed);
+		task.setLocked(em.find(Node.class, node));
+		return nodeRepository.saveAndFlush(task);
+	}
+
+	private TaskSampleSubscription subscriptionTask(final Date end, final boolean failed) {
+		final var task = new TaskSampleSubscription();
+		task.setAuthor(DEFAULT_USER);
+		task.setData("d");
+		task.setStart(new Date());
+		task.setEnd(end);
+		task.setFailed(failed);
+		task.setLocked(em.find(Subscription.class, subscription));
+		return subscriptionRepository.saveAndFlush(task);
+	}
+
+	private LongTaskRunnerVo runner(final List<LongTaskRunnerVo> runners, final String key) {
+		return runners.stream().filter(r -> key.equals(r.getKey())).findFirst().orElse(null);
+	}
+
+	@Test
+	void findAllEnumeratesAndClassifies() {
+		nodeTask("service:bt:jira", 1000, new Date(), false);
+		subscriptionTask(new Date(), false);
+
+		final var runners = resource.findAll();
+		final var node = runner(runners, NODE_RUNNER);
+		final var sub = runner(runners, SUBSCRIPTION_RUNNER);
+
+		Assertions.assertNotNull(node);
+		Assertions.assertEquals(TaskStatusType.NODE, node.getType());
+		Assertions.assertEquals("TaskSampleNode", node.getLabel());
+
+		Assertions.assertNotNull(sub);
+		Assertions.assertEquals(TaskStatusType.SUBSCRIPTION, sub.getType());
+		Assertions.assertEquals("TaskSampleSubscription", sub.getLabel());
+	}
+
+	@Test
+	void findAllComputesStats() {
+		nodeTask("service:bt:jira", 1000, null, false); // running
+		nodeTask("service:bt:jira:4", 2000, new Date(), false); // succeeded
+		nodeTask("service:bt:jira:6", 3000, new Date(), true); // failed
+
+		final var node = runner(resource.findAll(), NODE_RUNNER);
+		Assertions.assertNotNull(node);
+		final var stats = node.getStats();
+		Assertions.assertEquals(3, stats.total());
+		Assertions.assertEquals(1, stats.running());
+		Assertions.assertEquals(1, stats.succeeded());
+		Assertions.assertEquals(1, stats.failed());
+	}
+
+	@Test
+	void findTasksSortedByStartDesc() {
+		nodeTask("service:bt:jira", 1000, new Date(), false);
+		nodeTask("service:bt:jira:4", 3000, new Date(), false);
+		nodeTask("service:bt:jira:6", 2000, new Date(), false);
+
+		final var result = resource.findTasks(NODE_RUNNER, newUriInfo(), null);
+		Assertions.assertEquals(3, result.getRecordsTotal());
+		final var data = result.getData();
+		Assertions.assertEquals(3000, data.get(0).getStart().getTime());
+		Assertions.assertEquals(2000, data.get(1).getStart().getTime());
+		Assertions.assertEquals(1000, data.get(2).getStart().getTime());
+		// Node locked reference feeds the icon.
+		Assertions.assertEquals(TaskStatusType.NODE, data.get(0).getLocked().getType());
+		Assertions.assertEquals("service:bt:jira:4", data.get(0).getLocked().getNode());
+	}
+
+	@Test
+	void findTasksFilteredByStatus() {
+		nodeTask("service:bt:jira", 1000, null, false); // running
+		nodeTask("service:bt:jira:4", 2000, new Date(), false); // succeeded
+		nodeTask("service:bt:jira:6", 3000, new Date(), true); // failed
+
+		final var running = resource.findTasks(NODE_RUNNER, newUriInfo(), "running");
+		Assertions.assertEquals(1, running.getRecordsTotal());
+		Assertions.assertEquals(TaskStatus.RUNNING, running.getData().getFirst().getStatus());
+
+		final var failed = resource.findTasks(NODE_RUNNER, newUriInfo(), "failed");
+		Assertions.assertEquals(1, failed.getRecordsTotal());
+		Assertions.assertEquals(TaskStatus.FAILED, failed.getData().getFirst().getStatus());
+	}
+
+	@Test
+	void findTasksPaginated() {
+		nodeTask("service:bt:jira", 1000, new Date(), false);
+		nodeTask("service:bt:jira:4", 2000, new Date(), false);
+		nodeTask("service:bt:jira:6", 3000, new Date(), false);
+
+		final var uriInfo = newUriInfo();
+		uriInfo.getQueryParameters().putSingle("rows", "2");
+		uriInfo.getQueryParameters().putSingle("page", "1");
+		final var result = resource.findTasks(NODE_RUNNER, uriInfo, null);
+		Assertions.assertEquals(3, result.getRecordsTotal());
+		Assertions.assertEquals(2, result.getData().size());
+	}
+
+	@Test
+	void findTasksSubscriptionLockedRef() {
+		subscriptionTask(new Date(), false);
+		final var result = resource.findTasks(SUBSCRIPTION_RUNNER, newUriInfo(), null);
+		Assertions.assertEquals(1, result.getRecordsTotal());
+		final var locked = result.getData().getFirst().getLocked();
+		Assertions.assertEquals(TaskStatusType.SUBSCRIPTION, locked.getType());
+		Assertions.assertEquals(subscription, locked.getSubscription().intValue());
+		Assertions.assertNotNull(locked.getProject());
+		Assertions.assertEquals("MDA", locked.getProject().name());
+	}
+
+	@Test
+	void notVisibleForOtherUser() {
+		nodeTask("service:bt:jira", 1000, new Date(), false);
+		subscriptionTask(new Date(), false);
+		// A user with no delegate / group membership and not admin sees nothing.
+		initSpringSecurityContext("any");
+
+		Assertions.assertEquals(0, resource.findTasks(NODE_RUNNER, newUriInfo(), null).getRecordsTotal());
+		Assertions.assertEquals(0, resource.findTasks(SUBSCRIPTION_RUNNER, newUriInfo(), null).getRecordsTotal());
+		Assertions.assertEquals(0, runner(resource.findAll(), NODE_RUNNER).getStats().total());
+	}
+
+	@Test
+	void findTasksUnknownKey() {
+		final UriInfo uriInfo = newUriInfo();
+		Assertions.assertThrows(NotFoundException.class, () -> resource.findTasks("unknown", uriInfo, null));
+	}
+}


### PR DESCRIPTION
Backend for ligoj/plugin-ui#44 (long-task management UI). Adds a read-only, admin-only REST surface under
`system/task` (package org.ligoj.app.resource.task):
- GET rest/system/task : enumerates every LongTaskRunner bean (applicationContext.getBeansOfType),
  classifies node / subscription / other (instanceof), returns per-runner stats {total,running,succeeded,failed}.
- GET rest/system/task/{key}?rows&page&sidx&sord&status : TableItem<TaskVo> for one runner, status derived
  (running=end null, failed, succeeded), ordered by start desc, in-memory pagination (1 task max per locked
  entity) via PageImpl. 404 on unknown key.
Adds LongTaskSubscriptionRepository.findAllVisible(user) (VISIBLE_PROJECTS, mirror of the existing node one).
Admin-only relies on the default RBAC (ADMIN=.*), no authorization csv change. cc @fdaugan
mvn install: 383 tests green. Merge/deploy before the plugin-ui + host PRs.
